### PR TITLE
Flare Standalone Documentation removed from search index 

### DIFF
--- a/docs/resources/stacks/flare/configuration_templates.md
+++ b/docs/resources/stacks/flare/configuration_templates.md
@@ -2,30 +2,27 @@
 
 Flare Configuration Templates offer comprehensive settings for facilitating data reading and writing operations with the Flare Stack. Flare empowers developers to interact with diverse data sources that support [depots](/resources/depot). These templates are specifically designed to support a broad spectrum of depots, encompassing Object Storage, Relational Databases, NoSQL Databases, Data Warehouses, etc.
 
-
 ## Supported Data Sources
 
 <center>
 
-|Name|Category|Flare Configuration|Flare Standalone Configuration|
-|---|---|---|---|
-|Amazon Redshift|Data Warehouse| [Read/Write](/resources/stacks/flare/configuration_templates/amazon_redshift/)|[Read/Write](/resources/stacks/flare/standalone/standalone_yaml_configurations/amazon_redshift)|
-|Amazon S3|Object Storage| [Read/Write](/resources/stacks/flare/configuration_templates/object_storage_depots/)|[Read/Write](/resources/stacks/flare/standalone/standalone_yaml_configurations/amazon_s3)|
-|Azure ABFSS|Object Storage| [Read/Write](/resources/stacks/flare/configuration_templates/object_storage_depots/)|[Read/Write](/resources/stacks/flare/standalone/standalone_yaml_configurations/azure_abfss)|
-|Azure WASBS|Object Storage| [Read/Write](/resources/stacks/flare/configuration_templates/object_storage_depots)|Not Supported|
-|Google Bigquery|Data Warehouse| [Read/Write](/resources/stacks/flare/configuration_templates/google_bigquery/)|[Read/Write](/resources/stacks/flare/standalone/standalone_yaml_configurations/google_bigquery/)|
-|Elasticsearch|NoSQL Database| [Read/Write](/resources/stacks/flare/configuration_templates/elasticsearch/)|[Read/Write](/resources/stacks/flare/standalone/standalone_yaml_configurations/elasticsearch/)|
-|Eventhub|Streaming Source| [Read/Write](/resources/stacks/flare/configuration_templates/eventhub/)|[Read/Write](/resources/stacks/flare/standalone/standalone_yaml_configurations/eventhub/)|
-|Google Cloud Storage|Object Storage| [Read/Write](/resources/stacks/flare/configuration_templates/object_storage_depots/)|[Read/Write](/resources/stacks/flare/standalone/standalone_yaml_configurations/google_cloud_storage/)|
-|Kafka|Streaming Source| [Read/Write](/resources/stacks/flare/configuration_templates/kafka/)|[Read/Write](/resources/stacks/flare/standalone/standalone_yaml_configurations/kafka/)|
-|Local|Local| Not Supported|[Read/Write](/resources/stacks/flare/standalone/standalone_yaml_configurations/local/)|
-|MySQL|Relational Database| [Read/Write](/resources/stacks/flare/configuration_templates/mysql/)|[Read/Write](/resources/stacks/flare/standalone/standalone_yaml_configurations/mysql/)|
-|MS-SQL|Relational Database| [Read/Write](/resources/stacks/flare/configuration_templates/mssql/)|Not Supported|
-|Postgres|Relational Database| [Read/Write](/resources/stacks/flare/configuration_templates/postgres/)|[Read/Write](/resources/stacks/flare/standalone/standalone_yaml_configurations/postgres/)|
-|Opensearch|NoSQL Database| [Read/Write](/resources/stacks/flare/configuration_templates/opensearch/)|[Read/Write](/resources/stacks/flare/standalone/standalone_yaml_configurations/opensearch/)|
-|Oracle|Relational Database| [Read/Write](/resources/stacks/flare/configuration_templates/oracle/)|Not Supported|
-|Pulsar|Streaming Source| [Read/Write](/resources/stacks/flare/configuration_templates/pulsar/)|[Read/Write](/resources/stacks/flare/standalone/standalone_yaml_configurations/pulsar/)|
-|Snowflake|Data Warehouse| [Read/Write](/resources/stacks/flare/configuration_templates/snowflake/)|[Read/Write](/resources/stacks/flare/standalone/standalone_yaml_configurations/snowflake/)|
+| Name             | Category         | Flare Configuration                                                                 |
+|------------------|------------------|------------------------------------------------------------------------------------|
+| Amazon Redshift  | Data Warehouse    | [Read/Write](/resources/stacks/flare/configuration_templates/amazon_redshift/)      |
+| Amazon S3        | Object Storage    | [Read/Write](/resources/stacks/flare/configuration_templates/object_storage_depots/)|
+| Azure ABFSS      | Object Storage    | [Read/Write](/resources/stacks/flare/configuration_templates/object_storage_depots/)|
+| Azure WASBS      | Object Storage    | [Read/Write](/resources/stacks/flare/configuration_templates/object_storage_depots) |
+| Google Bigquery  | Data Warehouse    | [Read/Write](/resources/stacks/flare/configuration_templates/google_bigquery/)      |
+| Elasticsearch    | NoSQL Database    | [Read/Write](/resources/stacks/flare/configuration_templates/elasticsearch/)        |
+| Eventhub         | Streaming Source  | [Read/Write](/resources/stacks/flare/configuration_templates/eventhub/)             |
+| Google Cloud Storage | Object Storage| [Read/Write](/resources/stacks/flare/configuration_templates/object_storage_depots/)|
+| Kafka            | Streaming Source  | [Read/Write](/resources/stacks/flare/configuration_templates/kafka/)               |
+| MySQL            | Relational Database| [Read/Write](/resources/stacks/flare/configuration_templates/mysql/)               |
+| MS-SQL           | Relational Database| [Read/Write](/resources/stacks/flare/configuration_templates/mssql/)               |
+| Postgres         | Relational Database| [Read/Write](/resources/stacks/flare/configuration_templates/postgres/)            |
+| Opensearch       | NoSQL Database    | [Read/Write](/resources/stacks/flare/configuration_templates/opensearch/)          |
+| Oracle           | Relational Database| [Read/Write](/resources/stacks/flare/configuration_templates/oracle/)              |
+| Pulsar           | Streaming Source  | [Read/Write](/resources/stacks/flare/configuration_templates/pulsar/)              |
+| Snowflake        | Data Warehouse    | [Read/Write](/resources/stacks/flare/configuration_templates/snowflake/)           |
 
 </center>
-

--- a/docs/resources/stacks/flare/configurations.md
+++ b/docs/resources/stacks/flare/configurations.md
@@ -406,7 +406,7 @@ stackSpec:
 
 ### **`inputs`**
 
-**Description:** The `inputs` attribute comprises of input dataset configurations for reading data from various depots (in case of Flare) and various data sources (in case of Flare Standalone). 
+**Description:** The `inputs` attribute comprises of input dataset configurations for reading data from various depots and data sources. 
 
 | Data Type | Requirement | Default Value | Possible Value |
 | --- | --- | --- | --- |
@@ -889,7 +889,7 @@ stackSpec:
 ### **`outputs`**
 
 
-**Description:** The `outputs` attribute comprises of output dataset configurations for writing data from various depots (in case of Flare) and various data sources (in case of Flare Standalone). 
+**Description:** The `outputs` attribute comprises of output dataset configurations for writing data from various depots and data sources. 
 
 | Data Type | Requirement | Default Value | Possible Value |
 | --- | --- | --- | --- |

--- a/docs/resources/stacks/flare/creating_flare_jobs.md
+++ b/docs/resources/stacks/flare/creating_flare_jobs.md
@@ -310,7 +310,7 @@ INFO[0001] 🛠 apply...nothing
 
 </details>
     
-
+<!-- 
 ### **Testing the YAML on Flare Standalone**
 
 In spite of validating the YAML, there is a chance that the Flare job will fail in production which will result in a loss of both computing resources and time. To avoid such unforeseeable situations its the best practice to test the Flare job in the Flare Standalone before deploying it into production.
@@ -320,7 +320,7 @@ In spite of validating the YAML, there is a chance that the Flare job will fail 
 
 </aside>
 
-[Testing the Flare job on Flare Standalone](/resources/stacks/flare/creating_flare_jobs/testing_the_flare_job_on_flare_standalone/)
+[Testing the Flare job on Flare Standalone](/resources/stacks/flare/creating_flare_jobs/testing_the_flare_job_on_flare_standalone/) -->
 
 ### **Applying the YAML**
 

--- a/docs/resources/stacks/flare/creating_flare_jobs/testing_the_flare_job_on_flare_standalone.md
+++ b/docs/resources/stacks/flare/creating_flare_jobs/testing_the_flare_job_on_flare_standalone.md
@@ -1,3 +1,8 @@
+---
+search:
+  exclude: true
+---
+
 # Testing the Flare job on Flare Standalone
 
 

--- a/docs/resources/stacks/flare/index.md
+++ b/docs/resources/stacks/flare/index.md
@@ -89,11 +89,11 @@ The Flare Stack YAML consists of multitude of configuration settings tailored fo
 
 [Flare Functions](/resources/stacks/flare/functions/list/)
 
-## How to test Flare Jobs
+<!-- ## How to test Flare Jobs
 
 Before deploying your logic into production, thorough testing is crucial. Flare Standalone provides a powerful and reliable testing interface, allowing you to test your Flare Jobs locally on your system. It helps identify and address potential issues before deployment. Further information regarding Flare Standalone can be accessed by clicking the link below.
 
-[Flare Standalone](/resources/stacks/flare/standalone/)
+[Flare Standalone](/resources/stacks/flare/standalone/) -->
 
 ## How to optimize jobs in Flare
 

--- a/docs/resources/stacks/flare/standalone.md
+++ b/docs/resources/stacks/flare/standalone.md
@@ -1,3 +1,8 @@
+---
+search:
+  exclude: true
+---
+
 # Flare Standalone
 
 > While developing a new Flare data processing workflow, it's a good idea to confirm that your transformations will work in production. Flare Standalone is the easiest way to achieve this.

--- a/docs/resources/stacks/flare/standalone/case_scenarios.md
+++ b/docs/resources/stacks/flare/standalone/case_scenarios.md
@@ -1,3 +1,8 @@
+---
+search:
+  exclude: true
+---
+
 # Case Scenarios
 
 

--- a/docs/resources/stacks/flare/standalone/case_scenarios/cloud_to_local_using_standalone/getting_the_port_of_serviceurl_and_adminurl.md
+++ b/docs/resources/stacks/flare/standalone/case_scenarios/cloud_to_local_using_standalone/getting_the_port_of_serviceurl_and_adminurl.md
@@ -1,3 +1,8 @@
+---
+search:
+  exclude: true
+---
+
 # Getting the Port of ServiceUrl and AdminUrl
 
 - Open the Operations App 

--- a/docs/resources/stacks/flare/standalone/case_scenarios/cloud_to_local_using_standalone_2.0.md
+++ b/docs/resources/stacks/flare/standalone/case_scenarios/cloud_to_local_using_standalone_2.0.md
@@ -1,3 +1,8 @@
+---
+search:
+  exclude: true
+---
+
 # Cloud to Local - Using Standalone 2.0
 
 ## Case Scenario

--- a/docs/resources/stacks/flare/standalone/case_scenarios/create_customer360_using_standalone_1.0.md
+++ b/docs/resources/stacks/flare/standalone/case_scenarios/create_customer360_using_standalone_1.0.md
@@ -1,3 +1,8 @@
+---
+search:
+  exclude: true
+---
+
 # Create customer 360 using Standalone 1.0
 
 

--- a/docs/resources/stacks/flare/standalone/case_scenarios/local_to_cloud_using_standalone_2.0.md
+++ b/docs/resources/stacks/flare/standalone/case_scenarios/local_to_cloud_using_standalone_2.0.md
@@ -1,3 +1,8 @@
+---
+search:
+  exclude: true
+---
+
 # Local to Cloud using Standalone 2.0
 
 Let’s take a case scenario, where we read data from the Local system and write it to the environment Pulsar.

--- a/docs/resources/stacks/flare/standalone/case_scenarios/local_to_cloud_using_standalone_2.0/getting_the_port_of_serviceurl_and_adminurl.md
+++ b/docs/resources/stacks/flare/standalone/case_scenarios/local_to_cloud_using_standalone_2.0/getting_the_port_of_serviceurl_and_adminurl.md
@@ -1,3 +1,8 @@
+---
+search:
+  exclude: true
+---
+
 # Getting the Port of Service and AdminUrl
 
 - Open the Operations App 

--- a/docs/resources/stacks/flare/standalone/case_scenarios/local_to_local_using_dataos_cli.md
+++ b/docs/resources/stacks/flare/standalone/case_scenarios/local_to_local_using_dataos_cli.md
@@ -1,3 +1,8 @@
+---
+search:
+  exclude: true
+---
+
 # Local to Local - Using DataOS CLI
 
 This article is a step-by-step guide to run Flare Standalone using DataOS Command Line Interface to test your workflows and explore the sample data using SparkSQL.

--- a/docs/resources/stacks/flare/standalone/case_scenarios/local_to_local_using_docker.md
+++ b/docs/resources/stacks/flare/standalone/case_scenarios/local_to_local_using_docker.md
@@ -1,3 +1,8 @@
+---
+search:
+  exclude: true
+---
+
 # Local to Local - Using Docker
 
 This article is a step-by-step guide for downloading prerequisites to install Flare Standalone and exploring the sample data while also assisting the user in completing a guided assignment.

--- a/docs/resources/stacks/flare/standalone/case_scenarios/local_to_local_using_standalone_2.0.md
+++ b/docs/resources/stacks/flare/standalone/case_scenarios/local_to_local_using_standalone_2.0.md
@@ -1,3 +1,8 @@
+---
+search:
+  exclude: true
+---
+
 # Local to Local using Standalone 2.0
 
 Let’s take a case scenario, where we read data from the Local system and write it back locally.

--- a/docs/resources/stacks/flare/standalone/from_standalone_to_production.md
+++ b/docs/resources/stacks/flare/standalone/from_standalone_to_production.md
@@ -1,3 +1,8 @@
+---
+search:
+  exclude: true
+---
+
 # From Standalone to Production
 
 

--- a/docs/resources/stacks/flare/standalone/running_flare_standalone.md
+++ b/docs/resources/stacks/flare/standalone/running_flare_standalone.md
@@ -1,3 +1,8 @@
+---
+search:
+  exclude: true
+---
+
 # Running Flare Standalone
 
 

--- a/docs/resources/stacks/flare/standalone/running_flare_standalone/getting_the_port_of_service_and_adminurl.md
+++ b/docs/resources/stacks/flare/standalone/running_flare_standalone/getting_the_port_of_service_and_adminurl.md
@@ -1,3 +1,8 @@
+---
+search:
+  exclude: true
+---
+
 # Getting the Port of Service and AdminUrl
 
 

--- a/docs/resources/stacks/flare/standalone/standalone_2.0.md
+++ b/docs/resources/stacks/flare/standalone/standalone_2.0.md
@@ -1,3 +1,9 @@
+---
+search:
+  exclude: true
+---
+
+
 # Standalone 2.0
 
 

--- a/docs/resources/stacks/flare/standalone/standalone_yaml_configurations.md
+++ b/docs/resources/stacks/flare/standalone/standalone_yaml_configurations.md
@@ -1,3 +1,8 @@
+---
+search:
+  exclude: true
+---
+
 # Standalone YAML Configurations
 
 ![Flare Standalone ex.svg](/resources/stacks/flare/standalone/standalone_yaml_configurations/flare_standalone_ex.svg)

--- a/docs/resources/stacks/flare/standalone/standalone_yaml_configurations/amazon_redshift.md
+++ b/docs/resources/stacks/flare/standalone/standalone_yaml_configurations/amazon_redshift.md
@@ -1,3 +1,8 @@
+---
+search:
+  exclude: true
+---
+
 # Amazon Redshift
 
 

--- a/docs/resources/stacks/flare/standalone/standalone_yaml_configurations/amazon_s3.md
+++ b/docs/resources/stacks/flare/standalone/standalone_yaml_configurations/amazon_s3.md
@@ -1,3 +1,8 @@
+---
+search:
+  exclude: true
+---
+
 # Amazon Simple Storage Service (S3)
 
 

--- a/docs/resources/stacks/flare/standalone/standalone_yaml_configurations/azure_abfss.md
+++ b/docs/resources/stacks/flare/standalone/standalone_yaml_configurations/azure_abfss.md
@@ -1,3 +1,8 @@
+---
+search:
+  exclude: true
+---
+
 # Azure Blob Storage (ABFSS)
 
 ## Read Config

--- a/docs/resources/stacks/flare/standalone/standalone_yaml_configurations/elasticsearch.md
+++ b/docs/resources/stacks/flare/standalone/standalone_yaml_configurations/elasticsearch.md
@@ -1,3 +1,8 @@
+---
+search:
+  exclude: true
+---
+
 # Elasticsearch
 
 ## Read Config

--- a/docs/resources/stacks/flare/standalone/standalone_yaml_configurations/eventhub.md
+++ b/docs/resources/stacks/flare/standalone/standalone_yaml_configurations/eventhub.md
@@ -1,3 +1,8 @@
+---
+search:
+  exclude: true
+---
+
 # EventHub
 
 ## Read Config

--- a/docs/resources/stacks/flare/standalone/standalone_yaml_configurations/google_bigquery.md
+++ b/docs/resources/stacks/flare/standalone/standalone_yaml_configurations/google_bigquery.md
@@ -1,3 +1,8 @@
+---
+search:
+  exclude: true
+---
+
 # Google Bigquery
 
 

--- a/docs/resources/stacks/flare/standalone/standalone_yaml_configurations/google_cloud_storage.md
+++ b/docs/resources/stacks/flare/standalone/standalone_yaml_configurations/google_cloud_storage.md
@@ -1,3 +1,8 @@
+---
+search:
+  exclude: true
+---
+
 # Google Cloud Storage (GCS)
 
 ## Read Config

--- a/docs/resources/stacks/flare/standalone/standalone_yaml_configurations/kafka.md
+++ b/docs/resources/stacks/flare/standalone/standalone_yaml_configurations/kafka.md
@@ -1,3 +1,8 @@
+---
+search:
+  exclude: true
+---
+
 # Kafka
 
 ## Read Config

--- a/docs/resources/stacks/flare/standalone/standalone_yaml_configurations/local.md
+++ b/docs/resources/stacks/flare/standalone/standalone_yaml_configurations/local.md
@@ -1,3 +1,8 @@
+---
+search:
+  exclude: true
+---
+
 # Local
 
 ## Read Config

--- a/docs/resources/stacks/flare/standalone/standalone_yaml_configurations/mysql.md
+++ b/docs/resources/stacks/flare/standalone/standalone_yaml_configurations/mysql.md
@@ -1,3 +1,8 @@
+---
+search:
+  exclude: true
+---
+
 # MySQL
 
 

--- a/docs/resources/stacks/flare/standalone/standalone_yaml_configurations/opensearch.md
+++ b/docs/resources/stacks/flare/standalone/standalone_yaml_configurations/opensearch.md
@@ -1,3 +1,8 @@
+---
+search:
+  exclude: true
+---
+
 # Opensearch
 
 ## Read Config

--- a/docs/resources/stacks/flare/standalone/standalone_yaml_configurations/postgres.md
+++ b/docs/resources/stacks/flare/standalone/standalone_yaml_configurations/postgres.md
@@ -1,3 +1,8 @@
+---
+search:
+  exclude: true
+---
+
 # Postgres
 
 ## Read Config

--- a/docs/resources/stacks/flare/standalone/standalone_yaml_configurations/pulsar.md
+++ b/docs/resources/stacks/flare/standalone/standalone_yaml_configurations/pulsar.md
@@ -1,3 +1,8 @@
+---
+search:
+  exclude: true
+---
+
 # Pulsar
 
 ## Pre-requisites

--- a/docs/resources/stacks/flare/standalone/standalone_yaml_configurations/snowflake.md
+++ b/docs/resources/stacks/flare/standalone/standalone_yaml_configurations/snowflake.md
@@ -1,3 +1,8 @@
+---
+search:
+  exclude: true
+---
+
 # Snowflake
 
 


### PR DESCRIPTION
This pull request includes the following:
- Flare Standalone documentation from Search index of dataos.info, the pages of Flare Standalone documentation can still be accessed via link