### PR TITLE
Changed the sidebar width of dataos documentation

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -3664,7 +3664,7 @@ html .md-footer-meta.md-typeset a:hover {
     position: -webkit-sticky;
     position: sticky;
     top: 2.4rem;
-    width: 12.1rem
+    width: 20rem
 }
 
 @media print {

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -3657,6 +3657,7 @@ html .md-footer-meta.md-typeset a:hover {
     background-color: var(--md-default-fg-color--lightest)
 }
 
+/* changed default width from 12.1 to 14 rem */
 .md-sidebar {
     align-self: flex-start;
     flex-shrink: 0;
@@ -3664,7 +3665,7 @@ html .md-footer-meta.md-typeset a:hover {
     position: -webkit-sticky;
     position: sticky;
     top: 2.4rem;
-    width: 20rem
+    width: 14rem
 }
 
 @media print {


### PR DESCRIPTION
Adjusted the width of the left navigation bar in dataos.info, modify the `.md-sidebar` CSS rule. In the provided stylesheet:

```css
.md-sidebar {
    width: 12.1rem; /* ← I have changed this value */
    align-self: flex-start;
    flex-shrink: 0;
    padding: 1.2rem 0;
    position: -webkit-sticky;
    position: sticky;
    top: 2.4rem;
}
```

**Key changes**:
- Increased the `width` value (currently 12.1rem to 14rem), experimented with other values like 15 rem, and 20 rem didn't appear properly

**Additional considerations**:
I have verified that the sidebar is appearing properly from my end, but would still request @Aayushitmdc @shraddaa @NandaAtModern to validate whether all things are rendered properly. Let me know if further changes are needed.